### PR TITLE
Don't raise when a relation isn't loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+.elixir_ls

--- a/lib/cereal/serializer.ex
+++ b/lib/cereal/serializer.ex
@@ -146,12 +146,11 @@ defmodule Cereal.Serializer do
   end
 
   @doc false
-  @error Cereal.AssociationNotLoadedError
-  def get_relationship_data(struct, name, opts) do
+  def get_relationship_data(struct, name, _opts) do
     struct
     |> Map.get(name)
     |> case do
-      %{__struct__: Ecto.Association.NotLoaded} -> raise @error, rel: name, opts: opts
+      %{__struct__: Ecto.Association.NotLoaded} -> nil
       relations -> relations
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Cereal.Mixfile do
   use Mix.Project
 
-  @version "1.0.1"
+  @version "1.0.2"
 
   def project do
     [app: :cereal,

--- a/test/cereal/builders/entity_test.exs
+++ b/test/cereal/builders/entity_test.exs
@@ -34,7 +34,7 @@ defmodule Cereal.Builders.EntityTest do
   defmodule DefaultCommentRelationSerializer do
     use Cereal.Serializer
     attributes [:text]
-    has_one :author, serializer: UserSerializer, default: TestModel.User, include: true 
+    has_one :author, serializer: UserSerializer, default: TestModel.User, include: true
   end
 
   defmodule EmbedSerializer do
@@ -83,15 +83,6 @@ defmodule Cereal.Builders.EntityTest do
       expected = %Entity{id: 1, type: "comment", attributes: %{text: "A comment"}, rels: %{user: nil}}
 
       assert Entity.build(context) == expected
-    end
-
-    test "it will raise when trying to serialize a relation that returns an Ecto.Association.NotLoaded struct", %{context: context} do
-      data = %TestModel.Comment{id: 1, text: "A comment", user: %Ecto.Association.NotLoaded{}}
-      context = %{context | data: data, serializer: CommentSerializer}
-
-      assert_raise Cereal.AssociationNotLoadedError, fn ->
-        Entity.build(context)
-      end
     end
 
     test "it will skip non-included entities", %{context: context} do
@@ -149,13 +140,13 @@ defmodule Cereal.Builders.EntityTest do
       }
       context  = %{context | data: data, serializer: EmbedSerializer, opts: []}
       expected = %Entity{
-        id: 3, 
-        type: "embed", 
+        id: 3,
+        type: "embed",
         attributes: %{
-          text: "some_text", 
+          text: "some_text",
           comment: %{
-            id: 2, 
-            _type: "comment", 
+            id: 2,
+            _type: "comment",
             text: "a comment",
             user: %{
               id: 1,


### PR DESCRIPTION

Serialization should really be more flexible than that.