### PR TITLE
Introduces transform hook

### DIFF
--- a/lib/cereal/builders/entity.ex
+++ b/lib/cereal/builders/entity.ex
@@ -11,6 +11,8 @@ defmodule Cereal.Builders.Entity do
   end
 
   def build(%{serializer: serializer} = context) do
+    context = Map.put(context, :data, serializer.transform(context.data))
+
     %__MODULE__{
       id: serializer.id(context.data, context.conn),
       type: serializer.type(context.data, context.conn),

--- a/lib/cereal/serializer.ex
+++ b/lib/cereal/serializer.ex
@@ -46,6 +46,9 @@ defmodule Cereal.Serializer do
     quote do
       def __relations,  do: @relations
       def __attributes, do: @attributes
+
+      def transform(data), do: data
+      defoverridable [transform: 1]
     end
   end
 

--- a/test/cereal/builders/entity_test.exs
+++ b/test/cereal/builders/entity_test.exs
@@ -10,6 +10,14 @@ defmodule Cereal.Builders.EntityTest do
     def not_an_attr(_, _), do: true
   end
 
+  defmodule TransformedSerializer do
+    use Cereal.Serializer
+    attributes [:name]
+    def transform(data) do
+      %{name: data.name <> "-1"}
+    end
+  end
+
   defmodule CommentSerializer do
     use Cereal.Serializer
     attributes [:text]
@@ -190,6 +198,15 @@ defmodule Cereal.Builders.EntityTest do
           }]
         }
       }
+
+      assert Entity.build(context) == expected
+    end
+
+    test "it will modify attributes with a transform function", %{context: context} do
+      user = %TestModel.User{id: 1, name: "Johnny"}
+      context = %{context | data: user, serializer: TestModel.TransformedSerializer}
+
+      expected = %Entity{attributes: %{name: "Johnny-1"}}
 
       assert Entity.build(context) == expected
     end


### PR DESCRIPTION
Allows a serializer to implement a transform/1 hook that accepts the
incoming data and allows an arbitrary transformation. This is useful for
cases where you have to transform the data depending on multiple fields
which the `attributes` bit really can't accomplish.