### PR TITLE
[ENT-1878] - watermarking in share link index

### DIFF
--- a/lib/cereal/serializer.ex
+++ b/lib/cereal/serializer.ex
@@ -34,6 +34,7 @@ defmodule Cereal.Serializer do
 
       unquote(define_default_id())
       unquote(define_default_type(__CALLER__.module))
+      unquote(define_default_assigns())
       unquote(define_default_attributes())
       unquote(define_default_relationships())
       unquote(define_default_preload())
@@ -66,6 +67,13 @@ defmodule Cereal.Serializer do
       def type(), do: unquote(type_for_module)
       def type(_, _), do: type()
       defoverridable [type: 2]
+    end
+  end
+
+  defp define_default_assigns do
+    quote do
+      def assigns(_data, _conn), do: %{}
+      defoverridable [assigns: 2]
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,8 @@ defmodule Cereal.Mixfile do
     [
       {:ecto, ">= 2.0.0"},
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:scrivener, "~> 1.2 or ~> 2.0", optional: true}
+      {:scrivener, "~> 1.2 or ~> 2.0", optional: true},
+      {:plug_cowboy, "~> 2.0.2"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,15 @@
 %{
+  "cowboy": {:hex, :cowboy, "2.7.0", "91ed100138a764355f43316b1d23d7ff6bdb0de4ea618cb5d8677c93a7a2f115", [:rebar3], [{:cowlib, "~> 2.8.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "2.8.0", "fd0ff1787db84ac415b8211573e9a30a3ebe71b5cbff7f720089972b2319c8a4", [:rebar3], [], "hexpm"},
   "decimal": {:hex, :decimal, "1.4.0", "fac965ce71a46aab53d3a6ce45662806bdd708a4a95a65cde8a12eb0124a1333", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "2.1.4", "d1ba932813ec0e0d9db481ef2c17777f1cefb11fc90fa7c142ff354972dfba7e", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.8.3", "12d5f9796dc72e8ac9614e94bda5e51c4c028d0d428e9297650d09e15a684478", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm"},
+  "plug_cowboy": {:hex, :plug_cowboy, "2.0.2", "6055f16868cc4882b24b6e1d63d2bada94fb4978413377a3b32ac16c18dffba2", [:mix], [{:cowboy, "~> 2.5", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
+  "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
   "scrivener": {:hex, :scrivener, "2.3.0", "16b1d744202d47233798205447b35592d96a209241c566304f84ddef63c718b2", [:mix], [], "hexpm"},
 }

--- a/test/cereal_test.exs
+++ b/test/cereal_test.exs
@@ -2,7 +2,75 @@ defmodule CerealTest do
   use ExUnit.Case
   doctest Cereal
 
-  test "the truth" do
-    assert 1 + 1 == 2
+  defmodule UserSerializer do
+    use Cereal.Serializer
+    attributes [:name, :property_that_needs_context]
+
+    def property_that_needs_context(_, %{assigns: %{article_name: article_name, comment_id: comment_id}}) do
+      "My context is #{article_name} and comment with id #{comment_id}"
+    end
+  end
+
+  defmodule CommentSerializer do
+    use Cereal.Serializer
+    attributes [:text, :property_that_needs_context]
+    has_one :user, serializer: UserSerializer, include: true
+
+    def property_that_needs_context(_, %{assigns: %{article_name: article_name, request_id: request_id}}) do
+      "My context is #{article_name} and I still have access to the request id #{request_id}"
+    end
+
+    def assigns(%{id: id}, _) do
+      %{comment_id: id}
+    end
+    def assigns(data, conn), do: super(data, conn)
+  end
+
+  defmodule ArticleSerializer do
+    use Cereal.Serializer
+    attributes [:name]
+    has_one :author, serializer: UserSerializer, include: false
+    has_many :comments, serializer: CommentSerializer, include: true
+
+    def assigns(%{name: name}, _) do
+      %{article_name: name}
+    end
+    def assigns(data, conn), do: super(data, conn)
+  end
+
+  defmodule BlogSerializer do
+    use Cereal.Serializer
+    attributes [:name]
+    has_many :articles, serializer: ArticleSerializer, include: true
+
+    def name(_, %{assigns: %{request_id: request_id}}) do
+      "I still have access to request_id #{request_id}"
+    end
+  end
+
+  describe "#serialize/3" do
+    test "will allow assigning data to the conn on relationships" do
+      author = %TestModel.User{id: 1, name: "Johnny Test"}
+      comments1 = [%TestModel.Comment{id: 1, text: "A comment", user: author}]
+      comments2 = [%TestModel.Comment{id: 2, text: "A comment", user: author}]
+      article1 = %TestModel.Article{id: 1, name: "Article 1", comments: comments1, author: author}
+      article2 = %TestModel.Article{id: 2, name: "Article 2", comments: comments2, author: author}
+      blog = %TestModel.Blog{id: 1, articles: [article1, article2]}
+      serialized = Cereal.serialize(BlogSerializer, blog, %Plug.Conn{assigns: %{request_id: 22}})
+      assert serialized.name === "I still have access to request_id 22"
+
+      serialized_article1 = Enum.find(serialized.articles, fn a -> a.name == "Article 1" end)
+      [serialized_comment1] = serialized_article1.comments
+      # comment for article 1 and its preloaded user both have access to the correct conn assigns from article 1
+      assert serialized_comment1.property_that_needs_context == "My context is Article 1 and I still have access to the request id 22"
+      assert serialized_comment1.user.property_that_needs_context == "My context is Article 1 and comment with id 1"
+
+      serialized_article2 = Enum.find(serialized.articles, fn a -> a.name == "Article 2" end)
+      [serialized_comment2] = serialized_article2.comments
+      # comment for article 2 and its preloaded user both have access to the correct conn assigns from article 2
+      assert serialized_comment2.property_that_needs_context == "My context is Article 2 and I still have access to the request id 22"
+      assert serialized_comment2.user.property_that_needs_context == "My context is Article 2 and comment with id 2"
+
+    end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,10 @@
 ExUnit.start()
 
 # Models used for testing
+defmodule TestModel.Blog do
+  defstruct [:id, :name, :articles]
+end
+
 defmodule TestModel.Article do
   defstruct [:id, :name, :author, :comments]
 end


### PR DESCRIPTION
To support some of the work we need to do for session based watermarking
we need to be able to pass data from a share link to an asset's
serializer so we can see if the share link it's loaded from has
watermarking enabled.
This adds a `assigns/2` macro to the serializer that allow specifying
data you want to assign to the conn for every relationship loaded under
a certain entity.