### PR TITLE
Fix Conn error

### DIFF
--- a/lib/cereal/builders/entity.ex
+++ b/lib/cereal/builders/entity.ex
@@ -27,13 +27,16 @@ defmodule Cereal.Builders.Entity do
 
   # if an assigns/2 function was specified in the serializer - we'll add its
   # return value to the conn's assigns
-  defp do_assigns(%{serializer: serializer, conn: conn} = context) do
+  defp do_assigns(%{serializer: serializer, conn: %Plug.Conn{} = conn} = context) do
     conn =
       context.data
       |> serializer.assigns(conn)
       |> Enum.reduce(conn, fn {key, value}, acc -> assign(acc, key, value) end)
 
     Map.put(context, :conn, conn)
+  end
+  defp do_assigns(context) do
+    %{context | conn: %Plug.Conn{}} |> do_assigns()
   end
 
   defp attributes(%{serializer: serializer} = context) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Cereal.Mixfile do
   use Mix.Project
 
-  @version "1.1.0"
+  @version "1.2.0"
 
   def project do
     [app: :cereal,

--- a/test/cereal_test.exs
+++ b/test/cereal_test.exs
@@ -19,6 +19,9 @@ defmodule CerealTest do
     def property_that_needs_context(_, %{assigns: %{article_name: article_name, request_id: request_id}}) do
       "My context is #{article_name} and I still have access to the request id #{request_id}"
     end
+    def property_that_needs_context(_, %{assigns: %{article_name: article_name}}) do
+      "My context is #{article_name}"
+    end
 
     def assigns(%{id: id}, _) do
       %{comment_id: id}
@@ -46,6 +49,9 @@ defmodule CerealTest do
     def name(_, %{assigns: %{request_id: request_id}}) do
       "I still have access to request_id #{request_id}"
     end
+    def name(_, _) do
+      "I am a fallback prop"
+    end
   end
 
   describe "#serialize/3" do
@@ -69,6 +75,30 @@ defmodule CerealTest do
       [serialized_comment2] = serialized_article2.comments
       # comment for article 2 and its preloaded user both have access to the correct conn assigns from article 2
       assert serialized_comment2.property_that_needs_context == "My context is Article 2 and I still have access to the request id 22"
+      assert serialized_comment2.user.property_that_needs_context == "My context is Article 2 and comment with id 2"
+
+    end
+
+    test "will not error on empty conn" do
+      author = %TestModel.User{id: 1, name: "Johnny Test"}
+      comments1 = [%TestModel.Comment{id: 1, text: "A comment", user: author}]
+      comments2 = [%TestModel.Comment{id: 2, text: "A comment", user: author}]
+      article1 = %TestModel.Article{id: 1, name: "Article 1", comments: comments1, author: author}
+      article2 = %TestModel.Article{id: 2, name: "Article 2", comments: comments2, author: author}
+      blog = %TestModel.Blog{id: 1, articles: [article1, article2]}
+      serialized = Cereal.serialize(BlogSerializer, blog, %{})
+      assert serialized.name === "I am a fallback prop"
+
+      serialized_article1 = Enum.find(serialized.articles, fn a -> a.name == "Article 1" end)
+      [serialized_comment1] = serialized_article1.comments
+      # comment for article 1 and its preloaded user both have access to the correct conn assigns from article 1
+      assert serialized_comment1.property_that_needs_context == "My context is Article 1"
+      assert serialized_comment1.user.property_that_needs_context == "My context is Article 1 and comment with id 1"
+
+      serialized_article2 = Enum.find(serialized.articles, fn a -> a.name == "Article 2" end)
+      [serialized_comment2] = serialized_article2.comments
+      # comment for article 2 and its preloaded user both have access to the correct conn assigns from article 2
+      assert serialized_comment2.property_that_needs_context == "My context is Article 2"
       assert serialized_comment2.user.property_that_needs_context == "My context is Article 2 and comment with id 2"
 
     end


### PR DESCRIPTION
Sometimes we pass the serializer an empty object as the Conn, so assigning
to it can error since it requires a Plug.Conn to be passed to assign/3.
This adds a check for that which will create that conn so it can be assigned
props.

Also bumps version to 1.2.0

Sentry error: https://sentry.io/organizations/frameio/issues/1477913886