### PR TITLE
Allow optional access to conn from transform function

### DIFF
--- a/lib/cereal/builders/entity.ex
+++ b/lib/cereal/builders/entity.ex
@@ -14,7 +14,7 @@ defmodule Cereal.Builders.Entity do
   def build(%{serializer: serializer} = context) do
     context =
       context
-      |> Map.put(:data, serializer.transform(context.data))
+      |> Map.put(:data, serializer.transform(context.data, context.conn))
       |> do_assigns()
 
     %__MODULE__{

--- a/lib/cereal/serializer.ex
+++ b/lib/cereal/serializer.ex
@@ -38,9 +38,7 @@ defmodule Cereal.Serializer do
       unquote(define_default_attributes())
       unquote(define_default_relationships())
       unquote(define_default_preload())
-
-      def transform(data), do: data
-      defoverridable [transform: 1]
+      unquote(define_default_transform())
 
       @before_compile Cereal.Serializer
     end
@@ -57,6 +55,13 @@ defmodule Cereal.Serializer do
     quote do
       def id(data, _conn), do: Map.get(data, :id)
       defoverridable [id: 2]
+    end
+  end
+
+  defp define_default_transform do
+    quote do
+      def transform(data, _), do: data
+      defoverridable [transform: 2]
     end
   end
 

--- a/test/cereal/builders/entity_test.exs
+++ b/test/cereal/builders/entity_test.exs
@@ -13,8 +13,8 @@ defmodule Cereal.Builders.EntityTest do
   defmodule TransformedSerializer do
     use Cereal.Serializer
     attributes [:name]
-    def transform(data) do
-      %{name: data.name <> "-1"}
+    def transform(data, conn) do
+      %{name: data.name <> "-1-" <> conn.name}
     end
   end
 
@@ -202,11 +202,11 @@ defmodule Cereal.Builders.EntityTest do
       assert Entity.build(context) == expected
     end
 
-    test "it will modify attributes with a transform function", %{context: context} do
+    test "it will modify attributes with a transform/2 function", %{context: context} do
       user = %TestModel.User{id: 1, name: "Johnny"}
-      context = %{context | data: user, serializer: TransformedSerializer}
+      context = %{context | data: user, conn: %{name: "conn-name"}, serializer: TransformedSerializer}
 
-      expected = %Entity{attributes: %{name: "Johnny-1"}, type: "transformed"}
+      expected = %Entity{attributes: %{name: "Johnny-1-conn-name"}, type: "transformed"}
 
       assert Entity.build(context) == expected
     end


### PR DESCRIPTION
For some work related to internal watermarking, we optionally want to give the `transform` function a second argument, the conn.

Specifically, this is for allowing us to look at the current user in the asset's serializer's `transform` so that we can grab their role once and use it in subsequent calls (since it requires a db call and we don't want to do it multiple times).