### PR TITLE
[SERV-2464] Expand `serializer` aliases in has_one/has_many/embeds_one outside of macro bodies.

### DIFF
--- a/lib/cereal/serializer.ex
+++ b/lib/cereal/serializer.ex
@@ -181,15 +181,6 @@ defmodule Cereal.Serializer do
     end
   end
 
-  def aliases(opts) do
-    opts
-    |> Keyword.values()
-    |> Enum.filter(fn
-      {:__aliases__, _, _} -> true
-      _ -> false
-    end)
-  end
-
   defp expand_serializer_in_place(opts, alias_context, env) do
     Keyword.update!(opts, :serializer, &expand_alias(&1, alias_context, env))
   end


### PR DESCRIPTION
When referencing an associated serializer via `has_one`, `has_many` or `embeds_one`, any unexpanded aliases are dragged  through into the macro's body for latent expansion, rather than expanded on the spot, hence creating a senseless compile-time dependency between the two serializers. The solution is to expand the alias in-place, then inject the fully qualified module into the macro body.

Ecto also encountered this problem a while back, I've modelled our alias-expansion solution after theirs. Outright disabling of the lexical tracker during alias expansion results in incorrect 'unused alias' warnings.

https://github.com/elixir-ecto/ecto/commit/d7a54eeef70230fcfe5a3c6cf1de59e99943d241
https://github.com/elixir-ecto/ecto/commit/cadaced80a4fe200f21003da111ce801b48d1c07

Previously:

```sh
❯ touch lib/core/serializers/projects/asset.ex && mix compile
Compiling 230 files (.ex)
```

with this PR:

```sh
❯ touch lib/core/serializers/projects/asset.ex && mix compile
Compiling 192 files (.ex)
```

This is a small step towards reducing the frictional tax on development in the presence of the serializers (v3). From here, a decent quick-ish win would be to upgrade to elixir 1.11+, it's much smarter about import/require/struct dependencies.