### PR TITLE
fix massdriver compilation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Cereal.Mixfile do
   use Mix.Project
 
-  @version "1.4.0"
+  @version "1.4.1"
 
   def project do
     [
@@ -36,7 +36,7 @@ defmodule Cereal.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:ecto, "~> 3.9", only: :test},
+      {:ecto, "~> 3.9"},
       {:ex_doc, "~> 0.19", only: :dev},
       {:scrivener, "~> 1.2 or ~> 2.0", optional: true},
       {:plug, "~> 1.12"}


### PR DESCRIPTION
[FIND-615](https://frame-io.atlassian.net/browse/FIND-615)

As mentioned in this slack thread, https://frame-io.slack.com/archives/C2GNL4DQR/p1710449562875019 - the change limiting the ecto dependency to the test env caused compilation to fail in develop since it's referencing the Ecto.Changeset struct at compile time in all envs.

[FIND-615]: https://frame-io.atlassian.net/browse/FIND-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ